### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/rubyforgood/growhaus_stats.png?label=ready&title=Ready)](https://waffle.io/rubyforgood/growhaus_stats)
 # Growhaus Stats Tracker
 
 A statistics recording and tracking application made for the folks at [The Growhaus](http://www.thegrowhaus.org/).


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/rubyforgood/growhaus_stats

This was requested by a real person (user nevern02) on waffle.io, we're not trying to spam you.