### PR TITLE
Style department dashboards.

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,3 +1,10 @@
 .nav-wrapper .brand-logo {
   padding-left: 30px;
 }
+
+h3 small {
+  display: inline-block;
+  vertical-align: middle;
+  font-size: 40%;
+  margin-left: 1em;
+}

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -4,7 +4,12 @@ class FormsController < ApplicationController
   # GET /forms
   # GET /forms.json
   def index
-    @forms = Form.all
+    if params[:department]
+      @department = Department.find(params[:department])
+      @forms = Form.where(department: @department)
+    else
+      @forms = Form.all.includes(:department)
+    end
   end
 
   # GET /forms/1

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -19,7 +19,7 @@ class FormsController < ApplicationController
 
   # GET /forms/new
   def new
-    @form = Form.new
+    @form = Form.new(department_id: params[:department])
   end
 
   # GET /forms/1/edit

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1><%= @department.try(:name) || "All" %> Forms</h1>
+<h3><%= @department.try(:name) || "All" %> Forms</h3>
 
 <table>
   <thead>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,6 +1,18 @@
 <p id="notice"><%= notice %></p>
 
-<h3><%= @department.try(:name) || "All" %> Forms</h3>
+
+
+
+<h3>
+  <%= @department.try(:name) || "All" %> Forms
+
+  <%= link_to new_form_path(department: @department) do %>
+    <small>
+      <i class="mdi-lg mdi-action-note-add"></i>
+      New Form
+    </small>
+  <% end %>
+</h3>
 
 <table>
   <thead>
@@ -38,10 +50,3 @@
     <% end %>
   </tbody>
 </table>
-
-<br>
-
-<%= link_to new_form_path do %>
-  <i class="mdi-lg mdi-action-note-add"></i>
-  New Form
-<% end %>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,28 +1,39 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Listing Forms</h1>
+<h1><%= @department.try(:name) || "All" %> Forms</h1>
 
 <table>
   <thead>
     <tr>
       <th>Name</th>
-      <th>Google form url</th>
       <th>Frequency</th>
-      <th>Department</th>
-      <th colspan="3"></th>
+      <% unless @department %>
+        <th>Department</th>
+      <% end %>
+      <th colspan="2"><!-- Actions --></th>
     </tr>
   </thead>
 
   <tbody>
     <% @forms.each do |form| %>
       <tr>
-        <td><%= form.name %></td>
-        <td><%= form.google_form_url %></td>
-        <td><%= form.frequency %></td>
-        <td><%= form.department_id %></td>
-        <td><%= link_to 'Show', form %></td>
-        <td><%= link_to 'Edit', edit_form_path(form) %></td>
-        <td><%= link_to 'Destroy', form, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to form.name, form %></td>
+        <td><%= form.frequency.titlecase %></td>
+        <% unless @department %>
+          <td><%= form.department.name %></td>
+        <% end %>
+        <td>
+          <%= link_to edit_form_path(form) do %>
+            <i class="mdi-lg mdi-editor-mode-edit"></i>
+            Edit
+          <% end %>
+        </td>
+        <td>
+          <%= link_to form, method: :delete, data: { confirm: 'Are you sure?' } do %>
+            <i class="mdi-lg mdi-action-delete"></i>
+            Delete
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +41,7 @@
 
 <br>
 
-<%= link_to 'New Form', new_form_path %>
+<%= link_to new_form_path do %>
+  <i class="mdi-lg mdi-action-note-add"></i>
+  New Form
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,9 @@
       <% end %>
     </div>
 
-    <%= yield %>
+    <div class="container">
+      <%= yield %>
+    </div>
 
   </body>
 </html>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -2,7 +2,7 @@
   <ul>
     <%- Department.all.each do |department| %>
       <li>
-        <%= department.name %>
+        <%= link_to department.name, forms_path(department: department) %>
         <ul>
           <%- Form.where(department: department).each do |form| %>
             <li><%= link_to form.name, form_path(form) %></li>


### PR DESCRIPTION
Here’s what they look like:

![image](https://cloud.githubusercontent.com/assets/14930/9022394/a3d81874-3841-11e5-8a18-aba89c65530d.png)

Made a few changes from the comps — 

 - **Didn’t include the department selector.** Seems like we’ve got that covered in the primary navigation. 
 - **Don’t show department in table if viewing a department.** It’s a column full of the same word, seemed unnecessary. 
 - **Didn’t use the circular plus icon.** The Material thing is to use that as a floating (`position:fixed`) thing in the bottom right, not inline. The floaty shadow thing is supposed to indicate that. I just used a different plus-like icon instead.
 - **Included the words “Edit” and “Delete.”** There’s plenty of room to do so, and the icons were really small click targets without them.