### PR TITLE
Spreadsheet url 2

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,5 +1,6 @@
 class Form < ActiveRecord::Base
   belongs_to :department
-  validates :google_form_url, format: { with: /https:\/\/google.docs.com\/forms.*/, message: 'must start with "https://google.docs.com/forms..."'  }
+  validates :google_form_url, format: { with: /https:\/\/docs.google.com\/forms.*/, message: 'must start with "https://google.docs.com/forms..."'  }
+  validates :google_sheet_url, format: { with: /https:\/\/docs.google.com\/spreadsheet.*/, message: 'must start with "https://google.docs.com/spreadsheet..."'  }
 
 end

--- a/app/views/forms/_form.html.erb
+++ b/app/views/forms/_form.html.erb
@@ -1,13 +1,14 @@
 <%= form_for(@form) do |f| %>
   <% if @form.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@form.errors.count, "error") %> prohibited this form from being saved:</h2>
-
-      <ul>
-      <% @form.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
+    <div class="card blue-grey darken-1">
+      <div class="card-content white-text">
+        <span class="card-title"><%= pluralize(@form.errors.count, "error") %> prohibited this form from being saved:</span>
+        <ul>
+          <% @form.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
     </div>
   <% end %>
 
@@ -25,7 +26,7 @@
   </div>
   <div class="row">
     <div class="input-field col s12">
-      <%= f.text_field :google_form_url, placeholder: 'https://docs.google.com/forms/d/…', class: "validate"%>
+      <%= f.text_field :google_form_url, placeholder: 'https://docs.google.com/forms/d/…'%>
       <%= f.label :google_form_url, 'URL to Google Form' %>
     </div>
   </div>

--- a/app/views/forms/_form.html.erb
+++ b/app/views/forms/_form.html.erb
@@ -25,7 +25,7 @@
   </div>
   <div class="row">
     <div class="input-field col s12">
-      <%= f.text_field :google_form_url, placeholder: 'https://docs.google.com/forms/d/…' %>
+      <%= f.text_field :google_form_url, placeholder: 'https://docs.google.com/forms/d/…', class: "validate"%>
       <%= f.label :google_form_url, 'URL to Google Form' %>
     </div>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,9 @@ module GrowhausStats
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance|
+    html_tag
+    }
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
   end


### PR DESCRIPTION
Fixes an error where the ".google" and ".docs" were switched, thus making all new forms fail validations.