### PR TITLE
Touch up sidebar javascript.

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -1,16 +1,12 @@
-setupNav = function(){
-  $(".button-collapse").sideNav({
-    menuWidth: 300
+(function () {
+  var setupNav = function () {
+    $(".button-collapse").sideNav({
+      menuWidth: 300
+    });
+  };
+
+  $(document).on({
+    "ready": setupNav,
+    "page:load": setupNav
   });
-  $("#close-side-nav").click(function(){
-    $('.button-collapse').sideNav('hide');
-  })
-};
-
-$( document ).ready(function() {
-  setupNav();
-});
-
-$(document).on('page:load', function () {
-  setupNav();
-});
+})();


### PR DESCRIPTION
- No need to attach close event handlers, since we deleted the close button.
- Don’t forget the `var` to prevent a global variable leak.
- Wrap function in closure to isolate local variable.
- Add event listeners in one go instead of two.