### PR TITLE
Vertical align the sign-in dashboard.

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,3 +1,7 @@
+body, html, .full-height {
+  height: 100%;
+}
+
 nav {
   .button-collapse {
     margin-right: 1em;
@@ -28,19 +32,6 @@ h3 small {
   font-size: 40%;
   margin-left: 1em;
 }
-
-/* LOGIN PAGE */
-
-div.login-container {
-  padding-top: 10em;
-  text-align: center;
-  color: #fff
-}
-
-div.login-logo {
-  padding-bottom: 2em;
-}
-
 
 
 /* DASHBOARD */

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,8 +27,8 @@
       </div>
 
     <% else # no current_user %>
-      <div class="login-container">
-        <div class="container">
+      <div class="full-height valign-wrapper white-text center-align">
+        <div class="container valign">
           <%= yield %>
         </div>
       </div>


### PR DESCRIPTION
Instead of using hardcoded space, we can use the materialize vertical-align helper. This means that the mobile version of the site is a lot prettier.

Here’s what it looked like before:

![image](https://cloud.githubusercontent.com/assets/14930/9026479/946572ca-38fe-11e5-897b-cfc8ed6911da.png)

And now:

![image](https://cloud.githubusercontent.com/assets/14930/9026486/bec1c870-38fe-11e5-8c70-b96bc31da889.png)

