### PR TITLE
Move “Last Updated” below content on mobile.

### DIFF
--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col s9">
+  <div class="col m9">
     <h3>Data Entry</h3>
     <h5>
       <%= link_to "All", forms_path %> /
@@ -7,7 +7,7 @@
       <%= @form.name %> <small>(<%= @form.frequency %>)</small>
     </h5>
   </div>
-  <div class="col s3">
+  <div class="col m3">
     <p>
       Last Updated:
       <strong class="red-text"><%= @form.last_updated %></strong>


### PR DESCRIPTION
When we’re at small screen sizes, this wraps the “Last Updated” down to beneath the title.